### PR TITLE
Update call to FindDirectory

### DIFF
--- a/Controller.cpp
+++ b/Controller.cpp
@@ -290,7 +290,7 @@ void
 Controller::StartCapture()
 {
 	BPath path;
-	status_t status = find_directory(B_COMMON_TEMP_DIRECTORY, &path);
+	status_t status = find_directory(B_SYSTEM_TEMP_DIRECTORY, &path);
 	if (status != B_OK)
 		return;
 			


### PR DESCRIPTION
According to https://api.haiku-os.org/FindDirectory_8h.html , B_COMMON_TEMP_DIRECTORY doesn't exist any more, but B_SYSTEM_TEMP_DIRECTORY does.
