### PR TITLE
Fixed tab view spacing

### DIFF
--- a/BSCWindow.cpp
+++ b/BSCWindow.cpp
@@ -356,9 +356,11 @@ BSCWindow::_LayoutWindow()
 	BTabView* tabView = new BTabView("Tab View", B_WIDTH_FROM_LABEL);
 
 	BLayoutBuilder::Group<>(this, B_VERTICAL, 0)
-		.SetInsets(-2, -2)
 		.Add(fMenuBar)
-		.Add(tabView)
+		.AddGroup(B_VERTICAL)
+			.SetInsets(-2, B_USE_SMALL_SPACING, -2, 0)
+			.Add(tabView)
+		.End()
 		.AddGroup(B_HORIZONTAL)
 			.Add(fCamStatus)
 			.Add(fPauseButton)


### PR DESCRIPTION
The tab view was a bit cramped to the menu bar. Increase spacing there. The former -2 inset also cut off the top of the menu bar.

Before:

![before](https://github.com/jackburton79/bescreencapture/assets/6107158/b1dcbf6e-8295-4d4b-8b61-b1506810c8d3)


After:

![after](https://github.com/jackburton79/bescreencapture/assets/6107158/f9f8a209-0822-4726-8a43-d4a1e7b77e11)
